### PR TITLE
Remove typo3temp/DynCss/ too, when clearing page cache.

### DIFF
--- a/Classes/Hooks/T3libTcemainHook.php
+++ b/Classes/Hooks/T3libTcemainHook.php
@@ -21,6 +21,11 @@ class T3libTcemainHook {
 				PATH_site . 'typo3temp/Cache/Data/DynCss',
 				TRUE
 			);
+
+			GeneralUtility::rmdir(
+				PATH_site . 'typo3temp/DynCss',
+				TRUE
+			);
 		}
 	}
 }


### PR DESCRIPTION
Fixes files not being deleted with, at least, dyncss_scss.