### PR TITLE
[BUGFIX] Removed deprecated method call

### DIFF
--- a/Classes/Hooks/Backend/Toolbar/ClearCacheActionsHook.php
+++ b/Classes/Hooks/Backend/Toolbar/ClearCacheActionsHook.php
@@ -31,7 +31,7 @@ class ClearCacheActionsHook implements ClearCacheActionsHookInterface {
 				'id' => 'dyncss',
 				'title' => $this->getLanguageService()->sL('LLL:EXT:dyncss/Resources/Private/Language/locallang.xlf:dyncss.toolbar.clearcache.title', TRUE),
 				'description' => $this->getLanguageService()->sL('LLL:EXT:dyncss/Resources/Private/Language/locallang.xlf:dyncss.toolbar.clearcache.description', TRUE),
-				'href' => BackendUtility::getModuleUrl('tce_db') . '&vC=' . $this->getBackendUser()->veriCode() . '&cacheCmd=dyncss&ajaxCall=1' . BackendUtility::getUrlToken('tceAction'),
+				'href' => BackendUtility::getModuleUrl('tce_db', ['vC' => $this->getBackendUser()->veriCode(), 'cacheCmd' => 'dyncss', 'ajaxCall' => 1]),
 				'icon' => IconUtility::getSpriteIcon('extensions-dyncss-lightning-blue')
 			);
 			$optionValues[] = 'dyncss';


### PR DESCRIPTION
The generated URI will be the exact same as those who are generated from the core cache clearing URIs. Except that cacheCmd obviously is 'dyncss'.