### PR TITLE
Issue 34

### DIFF
--- a/Classes/Parser/AbstractParser.php
+++ b/Classes/Parser/AbstractParser.php
@@ -181,7 +181,8 @@ abstract class AbstractParser implements ParserInterface{
 			return $url;
 		}
 		// anything inside TYPO3 has to be adjusted
-                // the generated 
+                // the generated css is assumed to be in typo3temp/DynCss, thus we read the typo3 
+                // install root by going up 2 levels
 		return '../../' . dirname($this->removePrefixFromString(PATH_site, $this->inputFilename)) . '/' . $url;
 	}
 

--- a/Classes/Parser/AbstractParser.php
+++ b/Classes/Parser/AbstractParser.php
@@ -181,7 +181,8 @@ abstract class AbstractParser implements ParserInterface{
 			return $url;
 		}
 		// anything inside TYPO3 has to be adjusted
-		return '../../../../' . dirname($this->removePrefixFromString(PATH_site, $this->inputFilename)) . '/' . $url;
+                // the generated 
+		return '../../' . dirname($this->removePrefixFromString(PATH_site, $this->inputFilename)) . '/' . $url;
 	}
 
 	/**

--- a/Tests/Unit/Parser/DummyParserTest.php
+++ b/Tests/Unit/Parser/DummyParserTest.php
@@ -50,7 +50,7 @@ class tx_Dyncss_Parser_DummyParserTest extends \TYPO3\CMS\Core\Tests\UnitTestCas
 			'https://typo3.org'   => 'https://typo3.org',
 			'/absPath'            => '/absPath',
 			'data:suiehihsidgfiu' => 'data:suiehihsidgfiu',
-			'../../Public/Contrib/bootstrap/fonts/glyphicons-halflings-regular.eot' => '../../../../typo3conf/ext/dyncss/Resources/Public/Less/../../Public/Contrib/bootstrap/fonts/glyphicons-halflings-regular.eot',
+			'../../Public/Contrib/bootstrap/fonts/glyphicons-halflings-regular.eot' => '../../typo3conf/ext/dyncss/Resources/Public/Less/../../Public/Contrib/bootstrap/fonts/glyphicons-halflings-regular.eot',
 			PATH_site . 'yeah'    => '../../yeah'
 		);
 	}


### PR DESCRIPTION
The current implementation goes up 4 directory levels when a relative path is specified in a css (scss), thus leading to the following effect:

let's say, the root of the typo3 installation is 

http://localhost/foo/bar

The generated css is thus available under 

http://localhost/foo/bar/typo3temp/DynCss/style-xxxxxxx.css

If the scss contains a url reference, the post-processor rewrites the url and prefixes it with ../../../../

That means, relative to the generated css, it goes up to

http://localhost/

and looks for the orignal subdirectory (e.g. typo3conf) there.

This might not have a negative effect if the typo3 installation is in the root of the webspace, but causes this problem if it's installed in a subdirectory.

I modified the Parser to go up 2 levels instead of 4, which would be always the root of the typo3 installation as the generated .css is stored under typo3temp/DynCss

It works for me and I hope that this change does not break anything. I do not see a problem, but I admit that I do not really understand why it's currently going 4 levels up instead of 2. There must be a reason for that, but I do not really see it. Could anybody please explain?

An alternative might be to introduce support for "FILE:EXT":-Prefix in url.

Andreas