### PR TITLE
[BUGFIX] use new constants in TYPO3 8.x

### DIFF
--- a/Classes/Service/DyncssService.php
+++ b/Classes/Service/DyncssService.php
@@ -44,7 +44,7 @@ class DyncssService
     {
         if (TYPO3_MODE === 'FE') {
             $file = GeneralUtility::getFileAbsFileName($file);
-        } elseif (TYPO3_MODE === 'BE' && !TYPO3_cliMode) {
+        } elseif (TYPO3_MODE === 'BE' && !self::isCliMode()) {
             $file = GeneralUtility::resolveBackPath(PATH_typo3.$file);
         }
 
@@ -102,5 +102,19 @@ class DyncssService
         }
 
         return $overrides;
+    }
+
+    /**
+     * Check CLI mode depending on TYPO3 version
+     *
+     * @return int
+     */
+    protected static function isCliMode()
+    {
+        if (version_compare(TYPO3_version, '8.0', '<')) {
+            return TYPO3_cliMode;
+        } else {
+            return TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI;
+        }
     }
 }


### PR DESCRIPTION
Fix breaking change in for TYPO3 8.x
https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/8.0/Breaking-72368-TYPO3ConstantsRemoved.html